### PR TITLE
refact : 모바일 플로팅 버튼 ux개선

### DIFF
--- a/meoku/src/components/mobile/MobileFloatingButton.tsx
+++ b/meoku/src/components/mobile/MobileFloatingButton.tsx
@@ -136,7 +136,7 @@ interface FloatingButtonProps {
 const MobileFloatingButton: React.FC<FloatingButtonProps> = ({ onClick }) => {
   const [isMenuVisible, setIsMenuVisible] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [showTooltip, setShowTooltip] = useState(false);
+  const [showTooltip, setShowTooltip] = useState(true);
   const menuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -144,13 +144,17 @@ const MobileFloatingButton: React.FC<FloatingButtonProps> = ({ onClick }) => {
       if (!isMenuVisible) {
         setShowTooltip(true);
       }
-    }, 3000);
+    }, 20000);
 
     return () => clearTimeout(timer);
   }, [isMenuVisible]);
 
   const handleClick = () => {
-    setIsMenuVisible(!isMenuVisible);
+    if (showTooltip) {
+      setIsMenuVisible(false);
+    } else {
+      setIsMenuVisible(!isMenuVisible);
+    }
     setShowTooltip(false);
     onClick?.();
   };


### PR DESCRIPTION
## 🔎 작업 내용

**말풍선 노출 타이밍 조정**
    - 모바일 화면은 PC화면과 다르게 공간이 협소하여 말풍선이 자주 뜨면(현재 3초에 한번씩) 메뉴를 가려 UX가 나빠질 수 있음.
    - 이를 개선하여 공지 말풍선은 최초 시작할 때 노출하고, 이후에는 20초 간격으로  노출 되도록 변경.

**말풍선 로직 분리**
    - 사용자가 공지 말풍선을 닫았을 경우, 메뉴(AI 추천, 맛집 리스트, 원하는 메뉴 제안하기)는 자동으로 안뜨게 변경(유저가 온전히 메뉴만 보게끔 하기위해)
    - 대신, 사용자가 말풍선을 한 번 더 클릭했을 때만 메뉴(AI 추천, 맛집 리스트, 원하는 메뉴 제안하기) 항목이 노출되도록 구성함.
